### PR TITLE
Fix release PR body formatting in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
               --base main \
               --head "release-$VERSION" \
               --title "Release $VERSION" \
-              --body "Automated release PR for version $VERSION. This PR updates the version in pom.xml to match the release tag.")
+              --body "Automated release PR for version $VERSION. This PR updates the version in pom.xml to match the release tag."
             echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
             echo "Created PR: $PR_URL"
           else


### PR DESCRIPTION
This pull request makes a minor update to the release workflow by removing an unnecessary closing parenthesis from the command that creates the automated release pull request.